### PR TITLE
13 invalid dependencies when adding the package to unity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.0.2
+- fix: add version for TextMeshPro dependency to be able to import it in Unity 6.
+
 ## Version 2.0.1
 - add Newtonsoft.Json.dll
 - add Licenses for external libs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.interactive-scape.tuio_client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "displayName": "TUIO Client",
   "description": "TUIO Client package for TUIO 1.1 and TUIO 2.0",
   "unity": "2021.3",
@@ -31,6 +31,6 @@
     "url": "https://www.interactive-scape.com"
   },
   "dependencies": {
-    "com.unity.textmeshpro": ""
+    "com.unity.textmeshpro": "3.0.0"
   }
 }


### PR DESCRIPTION
# Fix Import Error for Unity 6

## Issuse
It was not possible to import the package via the unity package manager for Unity 6 because of missing version of the textmeshpro dependency.

![image](https://github.com/InteractiveScapeGmbH/TuioUnityClient/assets/51314413/9d3c6dbe-8103-4711-964c-8a9aafc1dc83)


## Changes
- add version to dependency

## How to test 
- start Unity 6
- in package manager add package by git url. enter: https://github.com/InteractiveScapeGmbH/TuioUnityClient.git#13-invalid-dependencies-when-adding-the-package-to-unity
- the package should be imported properly

![image](https://github.com/InteractiveScapeGmbH/TuioUnityClient/assets/51314413/3f39d287-2790-4446-bf1f-30b9187218b9)
